### PR TITLE
Update setup-fortran action

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -24,7 +24,7 @@ jobs:
             toolchain: {compiler: intel, version: '2023.2'}
 
     steps:
-      - uses: awvwgk/setup-fortran@v1.6.1
+      - uses: fortran-lang/setup-fortran@v1.6.1
         id: setup-fortran
         with:
           compiler: ${{ matrix.toolchain.compiler }}


### PR DESCRIPTION
The setup-fortran action moved to the @fortran-lang org, my original repo will continue working, but it is recommended to change to the new repository.